### PR TITLE
re Issue #1

### DIFF
--- a/merklelib/merkle.py
+++ b/merklelib/merkle.py
@@ -456,7 +456,7 @@ class MerkleTree(object):
     """
     mapping, hasher = self._mapping, self._hasher
     # assuming that leaf in hexadecimal representation
-    target = mapping.get(utils.from_hex(leaf))
+    target = mapping.get(leaf)
     if target is None:
       target = mapping.get(hasher.hash_leaf(leaf))
     # no leaf in mapping, return an empty AuditProof object


### PR DESCRIPTION
the problem is in line 459, merkle.py:  
```
target = mapping.get(utils.from_hex(leaf))
```  
since the method takes a _str_ (leaf from _hashfunc(data)_  due to hexdigest returning a str), _target_ will always be _None_ and always fail the conditional in line 460. Hence, the example "works" by changing it to passing in the (raw) data, since line 461 is always called and takes care of the hashing.

removing the from_hex conversion should take care of the issue.