### PR TITLE
Python 3.10 compatibility and general code reformat.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ python:
   - "3.3"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
+  - "3.10"
 
 install:
   - pip install -r requirements.txt

--- a/merklelib/__init__.py
+++ b/merklelib/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1"
+__version__ = "1.0"
 
 __all__ = [
     "MerkleTree",

--- a/merklelib/__init__.py
+++ b/merklelib/__init__.py
@@ -1,10 +1,16 @@
-
-__version__ = '1.0'
+__version__ = "1.1"
 
 __all__ = [
-    'MerkleTree', 'AuditProof', 'Hasher', 'verify_leaf_inclusion',
-    'verify_tree_consistency', 'AuditNode', 'beautify', 'jsonify', 'export'
-  ]
+    "MerkleTree",
+    "AuditProof",
+    "Hasher",
+    "verify_leaf_inclusion",
+    "verify_tree_consistency",
+    "AuditNode",
+    "beautify",
+    "jsonify",
+    "export",
+]
 
 from merklelib.merkle import *
 from merklelib.format import *

--- a/merklelib/compat.py
+++ b/merklelib/compat.py
@@ -2,16 +2,16 @@ import sys
 
 _ver = sys.version_info
 
-is_py2 = (_ver[0] == 2)
-is_py3 = (_ver[0] == 3)
+is_py2 = _ver[0] == 2
+is_py3 = _ver[0] == 3
 
 if is_py2:
-  bytes = str
-  str = unicode
-  basestring = basestring
-  bytes_types = (bytes, bytearray)
+    bytes = str
+    str = unicode
+    basestring = basestring
+    bytes_types = (bytes, bytearray)
 elif is_py3:
-  builtin_str = str
-  str = str
-  bytes = bytes
-  bytes_types = (bytes, bytearray)
+    builtin_str = str
+    str = str
+    bytes = bytes
+    bytes_types = (bytes, bytearray)

--- a/merklelib/merkle.py
+++ b/merklelib/merkle.py
@@ -248,7 +248,7 @@ def verify_leaf_inclusion(target, proof, hashobj, root_hash):
   paths = None
 
   # any collection containing AuditNode objects.
-  if isinstance(proof, collections.Iterable):
+  if isinstance(proof, collections.abc.Iterable):
     if isinstance(proof[0], AuditNode):
       paths = proof
   elif isinstance(proof, AuditProof):
@@ -426,7 +426,7 @@ class MerkleTree(object):
 
   def _build_tree(self, data):
     # convert to a tuple if not iterable already
-    if not isinstance(data, collections.Iterable):
+    if not isinstance(data, collections.abc.Iterable):
       data = (data, )
     self._root = None
     mapping = collections.OrderedDict()
@@ -571,7 +571,7 @@ class MerkleTree(object):
     """
     if isinstance(data, MerkleTree):
       data = data.leaves
-    elif not isinstance(data, collections.Iterable):
+    elif not isinstance(data, collections.abc.Iterable):
       data = (data, data)
     # traverse and append each item
     for item in data:

--- a/merklelib/merkle.py
+++ b/merklelib/merkle.py
@@ -39,7 +39,6 @@ import collections
 import abc
 import six
 import functools
-import io
 import math
 import time
 

--- a/merklelib/utils.py
+++ b/merklelib/utils.py
@@ -2,41 +2,40 @@ from merklelib.compat import bytes, str, bytes_types, is_py2
 
 import codecs
 import binascii
-import string
 
 
 def is_string(value):
-  return isinstance(value, bytes_types)
+    return isinstance(value, bytes_types)
 
 
 def to_string(value):
-  if isinstance(value, bytes_types):
-    return value
-  elif isinstance(value, str):
-    if not is_py2:
-      value = value.encode()
-    return value
-  else:
-    value = str(value)
-    if not is_py2:
-      value = value.encode()
-    return bytes(value)
+    if isinstance(value, bytes_types):
+        return value
+    elif isinstance(value, str):
+        if not is_py2:
+            value = value.encode()
+        return value
+    else:
+        value = str(value)
+        if not is_py2:
+            value = value.encode()
+        return bytes(value)
 
 
 def to_hex(value):
-  if not is_py2:
-    return to_string(value).hex()
-  return codecs.encode(to_string(value), 'hex')
+    if not is_py2:
+        return to_string(value).hex()
+    return codecs.encode(to_string(value), "hex")
 
 
 def from_hex(value):
-  try:
-    if not is_py2:
-      # this seems to be faster in Python 3
-      return bytes.fromhex(value)
-    return bytes(bytearray.fromhex(value))
-  except Exception as error:
-    if isinstance(error, binascii.Error):
-      raise
-    pass
-  return value
+    try:
+        if not is_py2:
+            # this seems to be faster in Python 3
+            return bytes.fromhex(value)
+        return bytes(bytearray.fromhex(value))
+    except Exception as error:
+        if isinstance(error, binascii.Error):
+            raise
+        pass
+    return value

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,11 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     cmdclass={
       'upload': UploadCommand,

--- a/tests/test_merkle.py
+++ b/tests/test_merkle.py
@@ -1,20 +1,17 @@
 # -*- coding: future_fstrings -*-
-import unittest
+import collections
 import hashlib
 import math
 import string
-import collections
+import unittest
 
 try:
-  import unittest.mock as mock
+    import unittest.mock as mock
 except ImportError:
-  import mock
+    import mock
 
-from os import urandom
 from random import choice
-from merklelib.compat import is_py2
 
-from merklelib import utils
 from merklelib.merkle import (
     Hasher,
     MerkleNode,
@@ -28,48 +25,52 @@ from merklelib.merkle import (
     verify_tree_consistency
 )
 
+
 def hashfunc(x):
-  return hashlib.sha256(x).digest()
+    return hashlib.sha256(x).digest()
 
 
 # used for side effects
 def mirror(x):
-  return x
+    return x
 
 
 # Adding __dict__ would allow to mock prototype methods
 class MerkleNode(MerkleNode):
-  __slots__ = ('__dict__', )
+    __slots__ = ('__dict__',)
 
 
 def patchdescriptor(cls, method, new):
-  if not hasattr(cls, method):
-    raise RuntimeError(f'{method} not found')
-  def _patchdescriptor(func):
-    def _wrapper(*args, **kwargs):
-      try:
-        current = getattr(cls, method)
-        setattr(cls, method, new)
-        result = func(*args, **kwargs)
-      finally:
-        setattr(cls, method, current)
-    return _wrapper
-  return _patchdescriptor
+    if not hasattr(cls, method):
+        raise RuntimeError(f'{method} not found')
+
+    def _patchdescriptor(func):
+        def _wrapper(*args, **kwargs):
+            try:
+                current = getattr(cls, method)
+                setattr(cls, method, new)
+                result = func(*args, **kwargs)
+            finally:
+                setattr(cls, method, current)
+
+        return _wrapper
+
+    return _patchdescriptor
 
 
 def _calculate_root(nodes):
-  hasher = Hasher(hashfunc)
-  while len(nodes) > 1:
-    if len(nodes) % 2 != 0:
-      nodes.append(nodes[-1])
-    a = iter(nodes)
-    nodes = []
-    for l, r in zip(a, a):
-      hashval = l
-      if hashval != r:
-        hashval = hasher.hash_children(l, r)
-      nodes.append(hashval)
-  return nodes[0]
+    hasher = Hasher(hashfunc)
+    while len(nodes) > 1:
+        if len(nodes) % 2 != 0:
+            nodes.append(nodes[-1])
+        a = iter(nodes)
+        nodes = []
+        for l, r in zip(a, a):
+            hashval = l
+            if hashval != r:
+                hashval = hasher.hash_children(l, r)
+            nodes.append(hashval)
+    return nodes[0]
 
 
 # commonly used objects across tests
@@ -81,224 +82,228 @@ to_hex.start()
 
 
 class MerkleTestCase(unittest.TestCase):
-  def test_hasher(self):
-    children = leaf * 2
-    classname = hasher.__class__.__name__
+    def test_hasher(self):
+        children = leaf * 2
+        classname = hasher.__class__.__name__
 
-    self.assertEqual(hasher.hash_leaf(leaf), hashfunc(b'\x00' + leaf))
-    self.assertEqual(hasher.hash_children(leaf, leaf), hashfunc(b'\x01'+children))
-    self.assertNotEqual(hasher.hashfunc, hashfunc)
-    self.assertEqual(hasher.hashfunc.__wrapped__, hashfunc)
-    self.assertEqual(str(hasher), f'{classname}({hashfunc})')
-    self.assertEqual(repr(hasher), f'{classname}({hashfunc})')
+        self.assertEqual(hasher.hash_leaf(leaf), hashfunc(b'\x00' + leaf))
+        self.assertEqual(hasher.hash_children(leaf, leaf), hashfunc(b'\x01' + children))
+        self.assertNotEqual(hasher.hashfunc, hashfunc)
+        self.assertEqual(hasher.hashfunc.__wrapped__, hashfunc)
+        self.assertEqual(str(hasher), f'{classname}({hashfunc})')
+        self.assertEqual(repr(hasher), f'{classname}({hashfunc})')
 
-  def test_merkle_node(self):
-    hashval = hashfunc(leaf)
+    def test_merkle_node(self):
+        hashval = hashfunc(leaf)
 
-    left, right = MerkleNode(hashval), MerkleNode(hashval)
-    node = MerkleNode(hashval, left=left, right=right)
+        left, right = MerkleNode(hashval), MerkleNode(hashval)
+        node = MerkleNode(hashval, left=left, right=right)
 
-    self.assertRaises(TypeError, MerkleNode, None)
-    self.assertRaises(TypeError, MerkleNode, bytes())
-    self.assertEqual(left.parent, right.parent)
-    self.assertEqual(left.hash, hashval)
-    self.assertEqual(right.hash, hashval)
-    self.assertEqual(left.type, LEFT)
-    self.assertEqual(right.type, RIGHT)
-    self.assertEqual(left.sibiling, right)
-    self.assertEqual(right.sibiling, left)
-    self.assertEqual(node.type, UNKNOWN)
-    self.assertIsNone(node.sibiling)
+        self.assertRaises(TypeError, MerkleNode, None)
+        self.assertRaises(TypeError, MerkleNode, bytes())
+        self.assertEqual(left.parent, right.parent)
+        self.assertEqual(left.hash, hashval)
+        self.assertEqual(right.hash, hashval)
+        self.assertEqual(left.type, LEFT)
+        self.assertEqual(right.type, RIGHT)
+        self.assertEqual(left.sibiling, right)
+        self.assertEqual(right.sibiling, left)
+        self.assertEqual(node.type, UNKNOWN)
+        self.assertIsNone(node.sibiling)
 
-  @patchdescriptor(MerkleNode, 'type', UNKNOWN)
-  def test_merkle_node_combine(self):
-    lefthash = hashfunc(b'\x01'+leaf)
-    righthash = hashfunc(b'\x02'+leaf)
+    @patchdescriptor(MerkleNode, 'type', UNKNOWN)
+    def test_merkle_node_combine(self):
+        lefthash = hashfunc(b'\x01' + leaf)
+        righthash = hashfunc(b'\x02' + leaf)
 
-    left, right = MerkleNode(lefthash), MerkleNode(righthash)
-    node = MerkleNode.combine(hasher, left, right)
+        left, right = MerkleNode(lefthash), MerkleNode(righthash)
+        node = MerkleNode.combine(hasher, left, right)
 
-    def _assert_all(finalhash):
-      self.assertEqual(node.hash, finalhash)
-      self.assertEqual(left.parent, right.parent)
-      self.assertEqual(left.hash, lefthash)
-      self.assertEqual(right.hash, righthash)
-      self.assertEqual(left.sibiling, right)
-      self.assertEqual(right.sibiling, left)
+        def _assert_all(finalhash):
+            self.assertEqual(node.hash, finalhash)
+            self.assertEqual(left.parent, right.parent)
+            self.assertEqual(left.hash, lefthash)
+            self.assertEqual(right.hash, righthash)
+            self.assertEqual(left.sibiling, right)
+            self.assertEqual(right.sibiling, left)
 
-    _assert_all(hasher.hash_children(lefthash, righthash))
+        _assert_all(hasher.hash_children(lefthash, righthash))
 
-    # testing concat(right, left)
-    left.type = RIGHT; right.type = LEFT
-    node = MerkleNode.combine(hasher, left, right)
+        # testing concat(right, left)
+        left.type = RIGHT;
+        right.type = LEFT
+        node = MerkleNode.combine(hasher, left, right)
 
-    _assert_all(hasher.hash_children(righthash, lefthash))
+        _assert_all(hasher.hash_children(righthash, lefthash))
 
-    # another case of concat(right, left)
-    left.type = LEFT
-    node = MerkleNode.combine(hasher, left, right)
+        # another case of concat(right, left)
+        left.type = LEFT
+        node = MerkleNode.combine(hasher, left, right)
 
-    _assert_all(hasher.hash_children(righthash, lefthash))
+        _assert_all(hasher.hash_children(righthash, lefthash))
 
-  def test_audit_proof(self):
-    hashes = list(string.ascii_letters)
-    nodes = [AuditNode(hash, choice([LEFT, RIGHT])) for hash in hashes]
+    def test_audit_proof(self):
+        hashes = list(string.ascii_letters)
+        nodes = [AuditNode(hash, choice([LEFT, RIGHT])) for hash in hashes]
 
-    proof = AuditProof(nodes)
-    items = ', '.join(hashes)
-    items_str = f'{{{items}}}'
+        proof = AuditProof(nodes)
+        items = ', '.join(hashes)
+        items_str = f'{{{items}}}'
 
-    self.assertEqual(proof.hex_nodes, hashes)
-    self.assertEqual(repr(proof), items_str)
-    self.assertEqual(str(proof), items_str)
+        self.assertEqual(proof.hex_nodes, hashes)
+        self.assertEqual(repr(proof), items_str)
+        self.assertEqual(str(proof), items_str)
 
-  def test_merkle_tree_init(self):
-    leaves = list(string.ascii_letters)
-    hashes = [hasher.hash_leaf(leaf) for leaf in leaves]
+    def test_merkle_tree_init(self):
+        leaves = list(string.ascii_letters)
+        hashes = [hasher.hash_leaf(leaf) for leaf in leaves]
 
-    # testing _init_hashfunc
-    self.assertRaises(TypeError, MerkleTree, leaves, leaves)
+        # testing _init_hashfunc
+        self.assertRaises(TypeError, MerkleTree, leaves, leaves)
 
-    tree = MerkleTree('a', mirror)
-    self.assertEqual(tree.hasher.hashfunc.__wrapped__, mirror)
+        tree = MerkleTree('a', mirror)
+        self.assertEqual(tree.hasher.hashfunc.__wrapped__, mirror)
 
-    tree = MerkleTree('a', None)
-    self.assertIsNotNone(tree.hasher)
+        tree = MerkleTree('a', None)
+        self.assertIsNotNone(tree.hasher)
 
-    # basic check
-    tree = MerkleTree(leaves, hasher)
-    self.assertEqual(tree.hexleaves, hashes)
-    self.assertEqual(tree.merkle_root, _calculate_root(hashes))
+        # basic check
+        tree = MerkleTree(leaves, hasher)
+        self.assertEqual(tree.hexleaves, hashes)
+        self.assertEqual(tree.merkle_root, _calculate_root(hashes))
 
-    # converting non iterable leaves to tuples
-    tree = MerkleTree('a', hasher)
-    self.assertEqual(tree.hexleaves, [hasher.hash_leaf('a')])
-    self.assertEqual(tree.merkle_root, hasher.hash_leaf('a'))
+        # converting non iterable leaves to tuples
+        tree = MerkleTree('a', hasher)
+        self.assertEqual(tree.hexleaves, [hasher.hash_leaf('a')])
+        self.assertEqual(tree.merkle_root, hasher.hash_leaf('a'))
 
-    # test case for empty root
-    tree = MerkleTree()
-    self.assertEqual(tree.hexleaves, [])
-    self.assertEqual(tree.merkle_root, None)
+        # test case for empty root
+        tree = MerkleTree()
+        self.assertEqual(tree.hexleaves, [])
+        self.assertEqual(tree.merkle_root, None)
 
-  def test_merkle_tree_get_proof(self):
-    chars = list(string.ascii_letters[:32])
-    tree = MerkleTree(chars, hasher)
+    def test_merkle_tree_get_proof(self):
+        chars = list(string.ascii_letters[:32])
+        tree = MerkleTree(chars, hasher)
 
-    self.assertEqual(tree.get_proof('invalid'), AuditProof([]))
+        self.assertEqual(tree.get_proof('invalid'), AuditProof([]))
 
-    # proof should contain log2 (n) of nodes
-    for char in chars:
-      expected = math.ceil(math.log(len(chars), 2))
-      # check for simple chars
-      proof = tree.get_proof(char)
-      self.assertEqual(len(proof), expected)
-      # check for hashed leaves
-      proof = tree.get_proof(hasher.hash_leaf(char))
-      self.assertEqual(len(proof), expected)
+        # proof should contain log2 (n) of nodes
+        for char in chars:
+            expected = math.ceil(math.log(len(chars), 2))
+            # check for simple chars
+            proof = tree.get_proof(char)
+            self.assertEqual(len(proof), expected)
+            # check for hashed leaves
+            proof = tree.get_proof(hasher.hash_leaf(char))
+            self.assertEqual(len(proof), expected)
 
-  def test_merkle_tree_update(self):
-    chars = string.ascii_letters
-    hash_mapping = collections.OrderedDict()
+    def test_merkle_tree_update(self):
+        chars = string.ascii_letters
+        hash_mapping = collections.OrderedDict()
 
-    for char in chars:
-      hash_mapping[char] = hasher.hash_leaf(char)
+        for char in chars:
+            hash_mapping[char] = hasher.hash_leaf(char)
 
-    tree = MerkleTree(chars, hasher)
-    initial_merkle_root = tree.merkle_root
+        tree = MerkleTree(chars, hasher)
+        initial_merkle_root = tree.merkle_root
 
-    # calculate the merkle root manually from hashes
-    current_root = _calculate_root(hash_mapping.values())
+        # calculate the merkle root manually from hashes
+        current_root = _calculate_root(hash_mapping.values())
 
-    self.assertEqual(initial_merkle_root, current_root)
-    self.assertRaises(KeyError, tree.update, 'invalid', 'a')
+        self.assertEqual(initial_merkle_root, current_root)
+        self.assertRaises(KeyError, tree.update, 'invalid', 'a')
 
-    for a, b in zip(chars, chars[::-1]):
-      prev_merkle_root = current_root
-      hash_mapping[a] = hasher.hash_leaf(b)
+        for a, b in zip(chars, chars[::-1]):
+            prev_merkle_root = current_root
+            hash_mapping[a] = hasher.hash_leaf(b)
 
-      # swap values
-      tree.update(a, b)
+            # swap values
+            tree.update(a, b)
 
-      # calculate the merkle root manually from hashes
-      current_root = _calculate_root(hash_mapping.values())
+            # calculate the merkle root manually from hashes
+            current_root = _calculate_root(hash_mapping.values())
 
-      self.assertNotEqual(tree.merkle_root, initial_merkle_root)
-      self.assertNotEqual(tree.merkle_root, prev_merkle_root)
-      self.assertEqual(tree.merkle_root, current_root)
+            self.assertNotEqual(tree.merkle_root, initial_merkle_root)
+            self.assertNotEqual(tree.merkle_root, prev_merkle_root)
+            self.assertEqual(tree.merkle_root, current_root)
 
-      # same thing for hash values for leaves
-      tree.update(hasher.hash_leaf(a), hasher.hash_leaf(b))
+            # same thing for hash values for leaves
+            tree.update(hasher.hash_leaf(a), hasher.hash_leaf(b))
 
-      self.assertNotEqual(tree.merkle_root, initial_merkle_root)
-      self.assertNotEqual(tree.merkle_root, prev_merkle_root)
-      self.assertEqual(tree.merkle_root, current_root)
+            self.assertNotEqual(tree.merkle_root, initial_merkle_root)
+            self.assertNotEqual(tree.merkle_root, prev_merkle_root)
+            self.assertEqual(tree.merkle_root, current_root)
 
-  def test_merkle_tree_append(self):
-    ascii = string.ascii_letters
-    hashes = [hasher.hash_leaf(char) for char in ascii]
+    def test_merkle_tree_append(self):
+        ascii = string.ascii_letters
+        hashes = [hasher.hash_leaf(char) for char in ascii]
 
-    tree = MerkleTree(hashobj=hasher)
+        tree = MerkleTree(hashobj=hasher)
 
-    # hash as one string
-    tree.append(ascii)
-    expected_hash = hasher.hash_leaf(ascii)
+        # hash as one string
+        tree.append(ascii)
+        expected_hash = hasher.hash_leaf(ascii)
 
-    self.assertEqual(len(tree), 1)
-    self.assertEqual(tree.merkle_root, expected_hash)
+        self.assertEqual(len(tree), 1)
+        self.assertEqual(tree.merkle_root, expected_hash)
 
-    # append every ascii character
-    tree.clear(); tree.extend(ascii)
-    expected_hash = _calculate_root(hashes)
+        # append every ascii character
+        tree.clear()
+        tree.extend(ascii)
+        expected_hash = _calculate_root(hashes)
 
-    self.assertEqual(len(tree), len(ascii))
-    self.assertEqual(tree.merkle_root, expected_hash)
+        self.assertEqual(len(tree), len(ascii))
+        self.assertEqual(tree.merkle_root, expected_hash)
 
-    # test all cases
-    for limit in range(1, len(ascii)):
-      tree.clear(); tree.extend(ascii[:limit])
-      expected_hash = _calculate_root(hashes[:limit])
+        # test all cases
+        for limit in range(1, len(ascii)):
+            tree.clear()
+            tree.extend(ascii[:limit])
+            expected_hash = _calculate_root(hashes[:limit])
 
-      self.assertEqual(len(tree), limit)
-      self.assertEqual(tree.merkle_root, expected_hash)
+            self.assertEqual(len(tree), limit)
+            self.assertEqual(tree.merkle_root, expected_hash)
 
-  def test_merkle_tree_equals(self):
-    a = MerkleTree(string.ascii_letters)
-    b = MerkleTree(string.ascii_letters)
+    def test_merkle_tree_equals(self):
+        a = MerkleTree(string.ascii_letters)
+        b = MerkleTree(string.ascii_letters)
 
-    self.assertEqual(a, b)
-    self.assertTrue(a.__eq__(b))
-    self.assertTrue(b.__eq__(a))
+        self.assertEqual(a, b)
+        self.assertTrue(a.__eq__(b))
+        self.assertTrue(b.__eq__(a))
 
-    a.append(1); b.append(2);
+        a.append(1)
+        b.append(2)
 
-    self.assertIsNot(a, b)
-    self.assertFalse(a.__eq__(b))
-    self.assertFalse(b.__eq__(a))
+        self.assertIsNot(a, b)
+        self.assertFalse(a.__eq__(b))
+        self.assertFalse(b.__eq__(a))
 
-  def test_verify_leaf_inclusion(self):
-    self.assertRaises(TypeError, verify_leaf_inclusion)
-    self.assertRaises(TypeError, verify_leaf_inclusion, None, None, hashfunc)
+    def test_verify_leaf_inclusion(self):
+        self.assertRaises(TypeError, verify_leaf_inclusion)
+        self.assertRaises(TypeError, verify_leaf_inclusion, None, None, hashfunc)
 
-    tree = MerkleTree(string.ascii_letters, hasher)
-    merkle_root = tree.merkle_root
+        tree = MerkleTree(string.ascii_letters, hasher)
+        merkle_root = tree.merkle_root
 
-    for leaf in string.ascii_letters:
-      proof = tree.get_proof(leaf)
-      hashval = hasher.hash_leaf(leaf)
+        for leaf in string.ascii_letters:
+            proof = tree.get_proof(leaf)
+            hashval = hasher.hash_leaf(leaf)
 
-      self.assertEqual(tree.get_proof(hashval), proof)
-      self.assertTrue(verify_leaf_inclusion(leaf, proof, hashfunc, merkle_root))
+            self.assertEqual(tree.get_proof(hashval), proof)
+            self.assertTrue(verify_leaf_inclusion(leaf, proof, hashfunc, merkle_root))
 
-  def test_verify_tree_consistency(self):
-    self.assertRaises(TypeError, verify_tree_consistency)
-    self.assertFalse(verify_tree_consistency(MerkleTree(), None, 10))
+    def test_verify_tree_consistency(self):
+        self.assertRaises(TypeError, verify_tree_consistency)
+        self.assertFalse(verify_tree_consistency(MerkleTree(), None, 10))
 
-    tree = MerkleTree(string.ascii_letters)
-    merkle_root = tree.merkle_root
+        tree = MerkleTree(string.ascii_letters)
+        merkle_root = tree.merkle_root
 
-    self.assertTrue(verify_tree_consistency(tree, merkle_root, len(tree)))
+        self.assertTrue(verify_tree_consistency(tree, merkle_root, len(tree)))
 
-    for size in range(1, len(tree)):
-      old_tree = MerkleTree(string.ascii_letters[:size])
-      merkle_root = old_tree.merkle_root
-      self.assertTrue(verify_tree_consistency(tree, merkle_root, size))
+        for size in range(1, len(tree)):
+            old_tree = MerkleTree(string.ascii_letters[:size])
+            merkle_root = old_tree.merkle_root
+            self.assertTrue(verify_tree_consistency(tree, merkle_root, size))


### PR DESCRIPTION
A hopefully straightforward PR that:

- Updates collections.iterable check to collections.abc.iterable - this becomes a breaking problem in python 3.10
- Reformats the codebase with black
- Updates the travis file to include more python versions.

I originally thought to increment the minor version number, but since there's no functional difference I have left it at 1.0

I've found this implementation to be useful and would like to continue using it :) 