### PR TITLE
Fix installation after black formatting changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ version = None
 
 
 with io.open(os.path.join(here, 'merklelib', '__init__.py'), encoding='utf-8') as fp:
-  version = re.compile(r".*__version__ = '(.*?)'", re.S).match(fp.read()).group(1)
+  version = re.compile(r".*__version__ = \"(.*?)\"", re.S).match(fp.read()).group(1)
 
 try:
   with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
(cc: @pritchardn)

The black formatting broke the regular expression used in setup.py to extract the version number of the library. It thus became impossible to install it.

This commit adjusts the regular expression so the version number can be extracted again successfully.

A question too: is there any chance we get a new release of the library on PyPI with an increased (minor?) version? Thanks!