### PR TITLE
Change __version__ = "1.0" to __version__ = '1.0' to prevent AttributeError: 'NoneType' object has no attribute 'group'

### DIFF
--- a/merklelib/__init__.py
+++ b/merklelib/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = '1.0'
 
 __all__ = [
     "MerkleTree",


### PR DESCRIPTION
When I run `pip install git+https://github.com/vpaliy/merklelib.git@0b10c9e7fd7145b1a57498d44e3e375f944c0076`, I get this output:  
```
<myusername>@<mycomputername> control_room % pip install git+https://github.com/vpaliy/merklelib.git@0b10c9e7fd7145b1a57498d44e3e375f944c0076
Collecting git+https://github.com/vpaliy/merklelib.git@0b10c9e7fd7145b1a57498d44e3e375f944c0076
  Cloning https://github.com/vpaliy/merklelib.git (to revision 0b10c9e7fd7145b1a57498d44e3e375f944c0076) to /private/var/folders/complex/path/onmyhd/pip-req-build-<randomlookingnum>
  Running command git clone --filter=blob:none --quiet https://github.com/vpaliy/merklelib.git /private/var/folders/complex/path/onmyhd/pip-req-build-<randomlookingnum>
  Running command git rev-parse -q --verify 'sha^0b10c9e7fd7145b1a57498d44e3e375f944c0076'
  Running command git fetch -q https://github.com/vpaliy/merklelib.git 0b10c9e7fd7145b1a57498d44e3e375f944c0076
  Resolved https://github.com/vpaliy/merklelib.git to commit 0b10c9e7fd7145b1a57498d44e3e375f944c0076
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/complex/path/onmyhd/pip-req-build-<randomlookingnum>/setup.py", line 25, in <module>
          version = re.compile(r".*__version__ = '(.*?)'", re.S).match(fp.read()).group(1)
      AttributeError: 'NoneType' object has no attribute 'group'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details
<myusername>@<mycomputername>
```  

This problem is corrected when I change `__version__ = "1.0"` to `__version__ = '1.0'`.