### PR TITLE
Upgrade collections

### DIFF
--- a/merklelib/merkle.py
+++ b/merklelib/merkle.py
@@ -1,4 +1,3 @@
-# -*- coding: future_fstrings -*-
 # -*- coding: utf-8 -*-
 
 """Merkle trees.
@@ -98,11 +97,15 @@ class Hasher(object):
     self.hashfunc = hashfunc
 
   def hash_leaf(self, data):
-    data = b'\x00' + utils.to_string(data)
+    data =  utils.to_string(data)
     return self._hashfunc(data)
 
   def hash_children(self, left, right):
-    data = b'\x01' + left + right
+    data =  left + right
+    if(left < right):
+      data = left + right
+    else:
+      data = right + left
     return self._hashfunc(data)
 
   @property
@@ -432,6 +435,7 @@ class MerkleTree(object):
     mapping = collections.OrderedDict()
     hasher = self._hasher
     nodes = [MerkleNode(hasher.hash_leaf(item)) for item in data]
+    nodes.sort(key = lambda leaf: leaf.hash)
     leaves = list(nodes)
     # build the tree and compute the merkle hash root
     while len(nodes) > 1:

--- a/merklelib/merkle.py
+++ b/merklelib/merkle.py
@@ -44,6 +44,11 @@ import time
 
 from merklelib import utils
 
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
+
 # used to indicate whether a leaf (or node) is the left or right child
 # or unknown yet
 LEFT, RIGHT, UNKNOWN = tuple(range(3))
@@ -251,7 +256,7 @@ def verify_leaf_inclusion(target, proof, hashobj, root_hash):
   paths = None
 
   # any collection containing AuditNode objects.
-  if isinstance(proof, collections.Iterable):
+  if isinstance(proof, collectionsAbc.Iterable):
     if isinstance(proof[0], AuditNode):
       paths = proof
   elif isinstance(proof, AuditProof):
@@ -429,10 +434,10 @@ class MerkleTree(object):
 
   def _build_tree(self, data):
     # convert to a tuple if not iterable already
-    if not isinstance(data, collections.Iterable):
+    if not isinstance(data, collectionsAbc.Iterable):
       data = (data, )
     self._root = None
-    mapping = collections.OrderedDict()
+    mapping = collectionsAbc.OrderedDict()
     hasher = self._hasher
     nodes = [MerkleNode(hasher.hash_leaf(item)) for item in data]
     nodes.sort(key = lambda leaf: leaf.hash)
@@ -575,7 +580,7 @@ class MerkleTree(object):
     """
     if isinstance(data, MerkleTree):
       data = data.leaves
-    elif not isinstance(data, collections.Iterable):
+    elif not isinstance(data, collectionsAbc.Iterable):
       data = (data, data)
     # traverse and append each item
     for item in data:


### PR DESCRIPTION
https://stackoverflow.com/questions/53978542/how-to-use-collections-abc-from-both-python-3-8-and-python-2-7/53978543#53978543

`merklelib` is supporting a broken version of `collections`. This was a bad upgrade by the library, so we patched it to use `collections.abc` for higher versions